### PR TITLE
move lifetime control of velocity providers from text view to package

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ Keyboard: Double-tap and hold the right Ctrl-key (key is configurable)
 Basic scrolling. While holding down the Ctrl-key, the document will scroll.
 Depending on which scroll profile is selected, the scroll will behave slightly different.
 
- For all profiles except _Dynamic_  the base functionality is, if you looked in the upper half of the editor view when double tapping the key, the scroll direction is up.
- And when you look in the lower half of the editor view, the scroll direction is down.
+For all profiles except _Dynamic_ the base functionality is, if you looked in the upper half of the editor view when double tapping the key, the scroll direction is up.
+And when you look in the lower half of the editor view, the scroll direction is down.
 
 These are the available scroll profiles:
 
-- _Static_: with no fancy acceleration/de-acceleration just a constant scroll speed.
+- _Static_: with no fancy acceleration/deacceleration just a constant scroll speed.
 - _Linear_: You can specify how long it will take to accelerate to max scroll speed.
 - _Exponential_: Has both acceleration and deacceleration (inertial).
 - _Dynamic_: Continuously modifies the scroll speed, and direction, depending on distance between your current gaze point and the vertical center of the document window.

--- a/source/EyeTrackingVsix/EyeTrackingVsix.csproj
+++ b/source/EyeTrackingVsix/EyeTrackingVsix.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Common\ScrollRequest.cs" />
     <Compile Include="Services\EyetrackerService.cs" />
     <Compile Include="Services\KeyboardEventService.cs" />
+    <Compile Include="Services\ScrollVelocityService.cs" />
     <Compile Include="Utils\Logger.cs" />
     <Compile Include="WpfTextViewListener.cs" />
   </ItemGroup>

--- a/source/EyeTrackingVsix/Features/Scroll/VelocityProviderFactory.cs
+++ b/source/EyeTrackingVsix/Features/Scroll/VelocityProviderFactory.cs
@@ -4,9 +4,9 @@ using EyeTrackingVsix.Options;
 
 namespace EyeTrackingVsix.Features.Scroll
 {
-    public static class VelocityProviderFactory
+    public class VelocityProviderFactory : IVelocityProviderFactory
     {
-        private static readonly Dictionary<ScrollType, Func<IVelocityProvider>> Generators = new Dictionary<ScrollType, Func<IVelocityProvider>>()
+        private static readonly Dictionary<ScrollType, Func<IVelocityProvider>> Generators = new Dictionary<ScrollType, Func<IVelocityProvider>>
         {
             { ScrollType.Static, () => new StaticVelocityProvider(new ScrollSettings(GeneralOptions.Instance)) },
             { ScrollType.Linear, () => new LinearVelocityProvider(new ScrollSettings(GeneralOptions.Instance)) },
@@ -14,9 +14,30 @@ namespace EyeTrackingVsix.Features.Scroll
             { ScrollType.Dynamic, () => new DynamicVelocityProvider(new ScrollSettings(GeneralOptions.Instance)) },
         };
 
-        public static IVelocityProvider Create(ScrollType type)
+        private static readonly Dictionary<ScrollType, Type> ImplementationTypeLookup = new Dictionary<ScrollType, Type>
+        {
+            { ScrollType.Static, typeof(StaticVelocityProvider) },
+            { ScrollType.Linear, typeof(LinearVelocityProvider) },
+            { ScrollType.Exponential, typeof(ExponentialVelocityProvider) },
+            { ScrollType.Dynamic, typeof(DynamicVelocityProvider) },
+        };
+
+        public bool VerifyProviderType(ScrollType type, IVelocityProvider provider)
+        {
+            return ImplementationTypeLookup.ContainsKey(type) 
+                && ImplementationTypeLookup[type] == provider?.GetType();
+        }
+
+        public IVelocityProvider Create(ScrollType type)
         {
             return Generators[type]();
         }
+    }
+
+    public interface IVelocityProviderFactory
+    {
+        bool VerifyProviderType(ScrollType type, IVelocityProvider provider);
+
+        IVelocityProvider Create(ScrollType type);
     }
 }

--- a/source/EyeTrackingVsix/Services/ScrollVelocityService.cs
+++ b/source/EyeTrackingVsix/Services/ScrollVelocityService.cs
@@ -1,0 +1,41 @@
+﻿using EyeTrackingVsix.Features.Scroll;
+using EyeTrackingVsix.Options;
+
+namespace EyeTrackingVsix.Services
+{
+    class ScrollVelocityService : SScrollVelocityService, IScrollVelocityService
+    {
+        private readonly IVelocityProviderFactory _factory;
+
+        private IVelocityProvider _current;
+
+        public ScrollVelocityService(Microsoft.VisualStudio.OLE.Interop.IServiceProvider serviceProvider)
+        {
+            _factory = new VelocityProviderFactory();
+        }
+
+        public bool HasVelocity => _current?.HasVelocity == true;
+
+        public double Velocity => _current?.Velocity ?? 0;
+        
+        public void Start(IRelativeGazeTransformer relativeGaze)
+        {
+            if (_current == null || _factory.VerifyProviderType(GeneralOptions.Instance.ScrollType, _current) == false)
+            {
+                _current = _factory.Create(GeneralOptions.Instance.ScrollType);
+            }
+            _current.Start(relativeGaze);
+        }
+
+        public void Stop()
+        {
+            _current.Stop();
+        }
+    }
+
+    public interface IScrollVelocityService : IVelocityProvider
+    { }
+
+    // see https://docs.microsoft.com/en-us/visualstudio/extensibility/how-to-provide-a-service?view=vs-2019
+    public interface SScrollVelocityService { }
+}

--- a/source/EyeTrackingVsix/WpfTextViewListener.cs
+++ b/source/EyeTrackingVsix/WpfTextViewListener.cs
@@ -20,12 +20,14 @@ namespace EyeTrackingVsix
     {
         private readonly IEyetrackerService _eyetracker;
         private readonly IKeyboardEventService _keyboardService;
+        private readonly IScrollVelocityService _scrollVelocityService;
 
         [ImportingConstructor]
         public WpfTextViewListener(SVsServiceProvider serviceProvider)
         {
             _eyetracker =  (IEyetrackerService)serviceProvider.GetService(typeof(SEyetrackerService));
             _keyboardService = (IKeyboardEventService)serviceProvider.GetService(typeof(SKeyboardEventService));
+            _scrollVelocityService = (IScrollVelocityService)serviceProvider.GetService(typeof(SScrollVelocityService));
         }
 
         /// <summary>
@@ -42,10 +44,7 @@ namespace EyeTrackingVsix
 
             if (GeneralOptions.Instance.ScrollEnabled)
             {
-                // TODO: make it possible to switch velocity provider in an open document
-                // NOTE: currently each open document will keep its velocity provider until the document is closed
-                var velocityProvider = VelocityProviderFactory.Create(GeneralOptions.Instance.ScrollType);
-                new GazeScroll(textView, _keyboardService, _eyetracker, velocityProvider);
+                new GazeScroll(textView, _keyboardService, _eyetracker, _scrollVelocityService);
             }
 
             if (GeneralOptions.Instance.CaretEnabled)


### PR DESCRIPTION
I created a scroll velocity service that handles the lifetime of the velocity providers. They are no longer tied to any document window. This should fix #8.